### PR TITLE
fix infinite recursion

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -872,7 +872,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @property
     def representation_component_names(self):
         out = OrderedDict()
-        if self._representation is None:
+        if self.representation is None:
             return out
         data_names = self.representation.attr_classes.keys()
         repr_names = self.representation_info[self.representation]['names']
@@ -883,7 +883,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @property
     def representation_component_units(self):
         out = OrderedDict()
-        if self._representation is None:
+        if self.representation is None:
             return out
         repr_attrs = self.representation_info[self.representation]
         repr_names = repr_attrs['names']
@@ -896,7 +896,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
     @property
     def differential_component_names(self):
         out = OrderedDict()
-        if self.representation is None or not self._data.differentials:
+        if (self.representation is None or
+            not getattr(self._data, 'differentials', None)):
             return out
 
         diff = self._data.differentials[0]


### PR DESCRIPTION
turns out there were *two* problems: 
* ``representation_component_names`` was changed to do ``self._representation`` instead of ``self.representation``.  That doesn't work because ``self.representation`` initializes an absent _representation.
* ``self._data.differential`` was failing when ``_data`` was None or ``differentials`` were absent